### PR TITLE
修复白名单内的表有可能get不到的情况

### DIFF
--- a/src/main/java/com/taobao/yugong/common/db/meta/TableMetaGenerator.java
+++ b/src/main/java/com/taobao/yugong/common/db/meta/TableMetaGenerator.java
@@ -52,13 +52,20 @@ public class TableMetaGenerator {
                 String sName = schemaName;
                 String tName = tableName;
                 DatabaseMetaData metaData = conn.getMetaData();
-                if (metaData.storesUpperCaseIdentifiers()) {
+                /*
+                    metaData中的storesUpperCaseIdentifiers，storesUpperCaseQuotedIdentifiers，
+                    storesLowerCaseIdentifiers,storesLowerCaseQuotedIdentifiers,
+                    storesMixedCaseIdentifiers,storesMixedCaseQuotedIdentifiers
+                    不足以判断sName,tName是否需要全部转大写或者小写，
+                    这个也取决于建表时的schemaName,tableName是否带引号
+                */
+                /*if (metaData.storesUpperCaseIdentifiers()) {
                     sName = StringUtils.upperCase(sName);
                     tName = StringUtils.upperCase(tName);
                 } else if (metaData.storesLowerCaseIdentifiers()) {
                     sName = StringUtils.lowerCase(sName);
                     tName = StringUtils.lowerCase(tName);
-                }
+                }*/
 
                 ResultSet rs = null;
                 rs = metaData.getTables(sName, sName, tName, new String[] { "TABLE" });

--- a/src/main/java/com/taobao/yugong/controller/YuGongController.java
+++ b/src/main/java/com/taobao/yugong/controller/YuGongController.java
@@ -107,7 +107,7 @@ public class YuGongController extends AbstractYuGongLifeCycle {
 
         int statBufferSize = config.getInt("yugong.stat.buffer.size", 16384);
         int statPrintInterval = config.getInt("yugong.stat.print.interval", 5);
-        // 是否滨行执行concurrent
+        // 是否并行执行concurrent
         boolean concurrent = config.getBoolean("yugong.table.concurrent.enable", false);
 
         Collection<TableHolder> tableMetas = initTables();


### PR DESCRIPTION
metaData中的storesUpperCaseIdentifiers，storesUpperCaseQuotedIdentifiers，storesLowerCaseIdentifiers,storesLowerCaseQuotedIdentifiers,storesMixedCaseIdentifiers,storesMixedCaseQuotedIdentifiers不足以判断sName,tName是否需要全部转大写或者小写，这个也取决于建表时的schemaName,tableName是否带引号，当写建表语句时，tableName小写，带引号，而且storesUpperCaseIdentifiers和storesLowerCaseIdentifiers都为true时，会出现metaData.getTables为空的情况
