### PR TITLE
修复白名单内的表扫描不到的bug

### DIFF
--- a/src/main/java/com/taobao/yugong/common/db/meta/TableMetaGenerator.java
+++ b/src/main/java/com/taobao/yugong/common/db/meta/TableMetaGenerator.java
@@ -405,11 +405,11 @@ public class TableMetaGenerator {
      * @throws SQLException
      */
     private static String getIdentifierName(String name, DatabaseMetaData metaData) throws SQLException {
-        if (metaData.storesMixedCaseIdentifiers()) {
+        if (metaData.storesMixedCaseIdentifiers()&&metaData.storesMixedCaseQuotedIdentifiers()) {
             return name; // 保留原始名
-        } else if (metaData.storesUpperCaseIdentifiers()) {
+        } else if (metaData.storesUpperCaseIdentifiers()&&metaData.storesUpperCaseQuotedIdentifiers) {
             return StringUtils.upperCase(name);
-        } else if (metaData.storesLowerCaseIdentifiers()) {
+        } else if (metaData.storesLowerCaseIdentifiers()&&metaData.storesLowerCaseQuotedIdentifiers) {
             return StringUtils.lowerCase(name);
         } else {
             return name;


### PR DESCRIPTION
当带引号和不带引号的存储都为true时获取到正确的表名，因为用户写建表语句时引号不是必须的