### PR TITLE
初始化AlarmService时，需要调用start方法，否则MailAlarmService的mailSender属性为null，发送邮…

### DIFF
--- a/src/main/java/com/taobao/yugong/controller/YuGongController.java
+++ b/src/main/java/com/taobao/yugong/controller/YuGongController.java
@@ -668,6 +668,7 @@ public class YuGongController extends AbstractYuGongLifeCycle {
             alarmService.setEmailUsername(config.getString("yugong.alarm.email.username"));
             alarmService.setStmpPort(config.getInt("yugong.alarm.email.stmp.port", 465));
             alarmService.setSslSupport(config.getBoolean("yugong.alarm.email.ssl.support", true));
+            alarmService.start();
             return alarmService;
         } else {
             return new LogAlarmService();


### PR DESCRIPTION
…件失败。

AlarmTest类的testMail用例也是类似的写法。