### PR TITLE
修复bug：queue为空导致的空指针异常

### DIFF
--- a/src/main/java/com/taobao/yugong/extractor/oracle/OracleFullRecordExtractor.java
+++ b/src/main/java/com/taobao/yugong/extractor/oracle/OracleFullRecordExtractor.java
@@ -68,13 +68,13 @@ public class OracleFullRecordExtractor extends AbstractOracleRecordExtractor {
             this.getMinPkSql = new MessageFormat(MIN_PK_FORMAT).format(new Object[] { primaryKey, schemaName, tableName });
         }
 
+		queue = new LinkedBlockingQueue<>(context.getOnceCrawNum() * 2);
         extractorThread = new NamedThreadFactory(this.getClass().getSimpleName() + "-"
                                                  + context.getTableMeta().getFullName()).newThread(new ContinueExtractor(this,
             context,
             queue));
-        extractorThread.start();
 
-        queue = new LinkedBlockingQueue<>(context.getOnceCrawNum() * 2);
+        extractorThread.start();
         tracer.update(context.getTableMeta().getFullName(), ProgressStatus.FULLING);
     }
 


### PR DESCRIPTION
在启动时，类ContinueExtractor的下面方法中，queue为空，会报空指针异常，
        for (Record record : result) {
            try {
                queue.put(record);
            } catch (InterruptedException e) {
                Thread.currentThread().interrupt(); // 传递
                throw new YuGongException(e);
            }
        }