### PR TITLE
Fix potential NPE exception

### DIFF
--- a/src/main/java/com/taobao/yugong/extractor/oracle/OracleFullRecordExtractor.java
+++ b/src/main/java/com/taobao/yugong/extractor/oracle/OracleFullRecordExtractor.java
@@ -68,13 +68,14 @@ public class OracleFullRecordExtractor extends AbstractOracleRecordExtractor {
             this.getMinPkSql = new MessageFormat(MIN_PK_FORMAT).format(new Object[] { primaryKey, schemaName, tableName });
         }
 
+        queue = new LinkedBlockingQueue<>(context.getOnceCrawNum() * 2);
+
         extractorThread = new NamedThreadFactory(this.getClass().getSimpleName() + "-"
                                                  + context.getTableMeta().getFullName()).newThread(new ContinueExtractor(this,
             context,
             queue));
         extractorThread.start();
 
-        queue = new LinkedBlockingQueue<>(context.getOnceCrawNum() * 2);
         tracer.update(context.getTableMeta().getFullName(), ProgressStatus.FULLING);
     }
 


### PR DESCRIPTION
Since the queue initialization line is after the thread start, so there
is a potential NPE once the `ContinueExtractor` is initialized before
the queue is initialized, so move the queue initlialization code before
the thread start line.

[Ticket: #92]