### PR TITLE
Old Fastjson has a serious security problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.8</version>
+            <version>1.2.68</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Fastjson has a serious security problem in 1.2.58,which will cause RCE
https://www.anquanke.com/post/id/199527
https://www.cnblogs.com/tr1ple/p/12348886.html
https://github.com/jas502n/fastjson-1.2.58-rce